### PR TITLE
Make search form configurable

### DIFF
--- a/ideabank.info
+++ b/ideabank.info
@@ -18,6 +18,7 @@ features[] = secondary_menu
 ;theme settings
 settings[background_image] = 1
 settings[libraries_logo] = 1
+settings[search_header] = 1
 
 stylesheets[all][] = css/main.css
 stylesheets[all][] = css/nav.css

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -112,13 +112,16 @@
 
 <?php print render($page['header']); ?>
 
-<div id="searchbox"> <!--MIT-Google search open -->
-    <?php
-    $block = block_load('google_appliance','ga_block_search_form');
-    $output = _block_get_renderable_array(_block_render_blocks(array($block)));
-    print drupal_render($output);
-    ?>
-</div><!-- MIT-Google search close -->
+<?php if (theme_get_setting('search_header')): ?>
+    <div id="searchbox"> <!--MIT-Google search open -->
+        <?php
+        $block = block_load('google_appliance','ga_block_search_form');
+        $output = _block_get_renderable_array(_block_render_blocks(array($block)));
+        print drupal_render($output);
+        ?>
+    </div><!-- MIT-Google search close -->
+<?php endif; ?>
+
 
 
 </div> <!-- header close -->

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -113,27 +113,11 @@
 <?php print render($page['header']); ?>
 
 <div id="searchbox"> <!--MIT-Google search open -->
-    <?php /*
-	<form method="get" action="http://search.mit.edu/search">
-	   <input type="text" name="q" size="20" maxlength="255" value=""/>
-	   <input type="submit" name="btnG" value=" Search the site"/>
-	   <input type="hidden" name="site" value="mit"/>
-	   <input type="hidden" name="client" value="mit"/>
-	   <input type="hidden" name="proxystylesheet" value="mit"/>
-	   <input type="hidden" name="output" value="xml_no_dtd"/>
-	   <input type="hidden" name="ie" value="UTF-8"/>
-	   <input type="hidden" name="as_dt" value="i"/>
-	    <input type="hidden" name="as_sitesearch" value="future-of-libraries.mit.edu"/>
-	</form>
-    */ ?>
     <?php
-    //$block = module_invoke('google_appliance', 'block_view', 'ga_block_search_form');
-    //print render($block['content']);
     $block = block_load('google_appliance','ga_block_search_form');
     $output = _block_get_renderable_array(_block_render_blocks(array($block)));
     print drupal_render($output);
     ?>
-
 </div><!-- MIT-Google search close -->
 
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -28,4 +28,11 @@ function ideabank_form_system_theme_settings_alter(&$form, $form_state) {
     '#description'   => t("Should the MIT Libraries' logo be displayed at the top of the site?"),
   );
 
+  $form['search_header'] = array(
+    '#type'          => 'checkbox',
+    '#title'         => t('Show search in header'),
+    '#default_value' => theme_get_setting('search_header'),
+    '#description'   => t("Should the Google CSE search form be displayed in the site header?"),
+  );
+
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -9,7 +9,19 @@
  * Adds background image control to theme settings.
  */
 function ideabank_form_system_theme_settings_alter(&$form, $form_state) {
-  $form['background_image'] = array(
+
+  // This puts all defined controls in a single fieldset, to match the way
+  // other controls are grouped.
+  $form['ideabank'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Ideabank settings'),
+    '#description' => t('These options will control how various aspects of the site will be (or will not be) displayed.'),
+    '#access' => user_access('administer site configuration') && user_access('access administration pages'),
+  );
+
+  // This enables the site builder to choose which background image is
+  // displayed on all pages.
+  $form['ideabank']['background_image'] = array(
     '#type'          => 'select',
     '#title'         => t('Background'),
     '#options'       => array(
@@ -21,14 +33,18 @@ function ideabank_form_system_theme_settings_alter(&$form, $form_state) {
     '#description'   => t("What image should be used as a background? Choosing 'None' will result in a gray gradient being displayed."),
   );
 
-  $form['libraries_logo'] = array(
+  // This determines whether the MIT Libaries' logo is displayed in the site
+  // masthead.
+  $form['ideabank']['libraries_logo'] = array(
     '#type'          => 'checkbox',
     '#title'         => t('Show MIT Libraries Logo'),
     '#default_value' => theme_get_setting('libraries_logo'),
     '#description'   => t("Should the MIT Libraries' logo be displayed at the top of the site?"),
   );
 
-  $form['search_header'] = array(
+  // This determines whether the search form (provided by a Google search
+  // appliance) is loaded in the site header.
+  $form['ideabank']['search_header'] = array(
     '#type'          => 'checkbox',
     '#title'         => t('Show search in header'),
     '#default_value' => theme_get_setting('search_header'),


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This converts the search form, currently implemented by the theme as an always-available piece of markup on the page header, to an optional element that can be enabled or disabled using a checkbox on the theme settings page.

Also with this change, we remove earlier implementations of this search form that were left as commented-out code, and re-organize the theme settings options to be better organized.

#### How can a reviewer manually see the effects of these changes?
Log into a site with an admin account, and load the theme settings page at `/admin/appearance/settings/ideabank`. You will find the options pictured below. Changing any of them should alter how the website displays.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-317

#### Screenshots (if appropriate)
Here is how the site settings will appear, at the path `/admin/appearance/settings/ideabank`
![image](https://user-images.githubusercontent.com/1403248/38203372-1a8f0096-366d-11e8-9cae-533251f1f318.png)

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
