### PR TITLE
Adds policy menu and associated styles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -503,6 +503,22 @@ p {
   margin-right: 4%;
 }
 
+#footer .policies {
+  float: right;
+}
+
+#footer .policies .item {
+  display: inline-block;
+}
+
+#footer .policies .item:after {
+  content: ' | ';
+}
+
+#footer .policies .item:last-child:after {
+  content: '';
+}
+
 #socialmediawidget {
   float: right;
   margin-top: 1%;

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -211,15 +211,17 @@
 <?php endif; ?>
 
 <div id="footer"  class="clearfix">
-
-
-
-<a href="http://web.mit.edu"><div id="footerlogo"></div></a>
-
-<div class="footertext"><?php print $site_name; ?><br />
-Massachusetts Institute of Technology<br />
-Cambridge MA 02139-4307
-</div>
+    <a href="http://web.mit.edu"><div id="footerlogo"></div></a>
+    <div class="footertext"><?php print $site_name; ?><br />
+        Massachusetts Institute of Technology<br />
+        Cambridge MA 02139-4307
+    </div>
+    <div class="policies">
+        <nav aria-label="MIT Libraries policy menu">
+            <span class="item"><a href="https://libraries.mit.edu/accessibility" class="link-sub">Accessibility</a></span>
+            <span class="item"><a href="https://libraries.mit.edu/privacy" class="link-sub">Privacy</a></span>
+        </nav>
+    </div>
 
 </div>
 


### PR DESCRIPTION
#### What does this PR do?
This adds the policies menu that is called for in the associated Jira tickets. It includes a change to the page template as well as the associated styles. I'm using the design library as a starting point for the markup, but this theme doesn't implement the design library to a significant extent.

#### Helpful background context (if appropriate)
This is part of a coordinated series of footer updates across all Libraries web applications.

#### How can a reviewer manually see the effects of these changes?
This update has been deployed to the dev site for the Future of Libraries. The URL is in Slack and in the UXWS-1006 ticket.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1006 (Future of Libraries)
- https://mitlibraries.atlassian.net/browse/UXWS-1007 (Open Access Task Force)

#### Screenshots (if appropriate)
More screenshots are in UXWS-1006, but this is how the footer will look now:
![Screen Shot 2020-10-05 at 3 47 27 PM](https://user-images.githubusercontent.com/1403248/95125400-e956e280-0722-11eb-9881-6d8d3984e1b3.png)


#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
